### PR TITLE
PA-14053-resque-pool-gem-update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,5 @@ rvm:
   - 1.8.7
   - 1.9.3
   - 2.0.0
+  - 2.1.2
 script: bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,6 @@ rvm:
   - 1.8.7
   - 1.9.3
   - 2.0.0
-  - 2.1.2
+  - 2.1
+  - 2.2
 script: bundle exec rake

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,5 +13,10 @@ Pull request guidelines
 4. Push your changes to your fork (`git push origin my_awesome_feature`)
 5. Open a [Pull Request](/nevans/resque-pool/pulls)
 
-Pull requests should have automated test coverage and new versions won't be
-released until they've been running in production for at least a week.
+Pull requests should have automated test coverage.
+
+New release policy
+------------------
+
+New versions won't be released until a release candidate has been running in a
+maintainer's production environment for at least a week.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+Contributing
+============
+
+We gladly accept help and bugfixes for resque-pool. We follow the guidelines of
+[semantic versioning](http://semver.org/) for all new gem releases.
+
+Pull request guidelines
+-----------------------
+
+1. Fork it and clone your new repo
+2. Create a branch (`git checkout -b my_awesome_feature`)
+3. Commit your changes (`git add my/awesome/file.rb; git commit -m "Added my awesome feature"`)
+4. Push your changes to your fork (`git push origin my_awesome_feature`)
+5. Open a [Pull Request](/nevans/resque-pool/pulls)
+
+Pull requests should have automated test coverage and new versions won't be
+released until they've been running in production for at least a week.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+## 0.6.0 _(unreleased)_
+
+ * no longer hijacks shutdown for normal resque worker processes.
+ * [jonleighton](https://github.com/jonleighton) pass worker instance to
+   `after_prefork` hook
+
 ## 0.5.0 (2015-03-24)
 
 Some more merges of long outstanding pull requests.
@@ -5,7 +11,6 @@ Some more merges of long outstanding pull requests.
  * _EVEN BETTER_ `TERM` support for Heroku than 0.4.0.  ;)
  * _DOCKER SUPPORT_ (don't go crazy when master pid is 1).
    _(example Dockerfile soon?)_
- * `resque-pool` no longer hijacks shutdown for normal resque worker processes.
  * `--spawn_delay` option in case workers respawn too quickly
  * Support `RUN_AT_EXIT_HOOKS`.
  * And [more](https://github.com/nevans/resque-pool/compare/v0.4.0...v0.5.0).

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,7 +8,7 @@ Some more merges of long outstanding pull requests.
  * `resque-pool` no longer hijacks shutdown for normal resque worker processes.
  * `--spawn_delay` option in case workers respawn too quickly
  * Support `RUN_AT_EXIT_HOOKS`.
- * And [more](https://github.com/nevans/resque-pool/compare/v0.4.0...v0.5.0.rc1).
+ * And [more](https://github.com/nevans/resque-pool/compare/v0.4.0...v0.5.0).
 
 Many thanks to the contributors! [JohnBat26](https://github.com/JohnBat26), Eric
 Chapweske, [werkshy](https://github.com/werkshy),
@@ -19,9 +19,12 @@ Chapweske, [werkshy](https://github.com/werkshy),
 ## 0.4.0 (2015-01-28)
 
 Another _long_ overdue maintenance release.  Many users had been running the
-various release candidates in production for over 16 months.  Better
-Heroku/`TERM_CHILD` support, better `upstart` process group control, ERB in the
-config file, not-insane package size, and more.
+various release candidates in production for over 16 months.  0.4.0 was based
+on 0.4.0.rc2 and 0.4.0.rc3 was rolled up into 0.5.0 instead.
+
+Better Heroku/`TERM_CHILD` support, better `upstart` process group control, ERB
+in the config file, not-insane package size, and
+[more](https://github.com/nevans/resque-pool/compare/v0.3.0...v0.4.0).
 
 Many thanks to the contributors!
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,8 @@
 ## 0.6.0 _(unreleased)_
 
  * no longer hijacks shutdown for normal resque worker processes.
+ * [PatrickTulskie](https://github.com/PatrickTulskie) Reopening log files now
+   reopens *all* logs in memory (append write only; code copied from Unicorn)
  * [jonleighton](https://github.com/jonleighton) pass worker instance to
    `after_prefork` hook
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,52 @@
-## 0.4.0.dev (unreleased)
+## 0.5.0 (2015-03-24)
 
- * ???
+Some more merges of long outstanding pull requests.
+
+ * _EVEN BETTER_ `TERM` support for Heroku than 0.4.0.  ;)
+ * _DOCKER SUPPORT_ (don't go crazy when master pid is 1).
+   _(example Dockerfile soon?)_
+ * `resque-pool` no longer hijacks shutdown for normal resque worker processes.
+ * `--spawn_delay` option in case workers respawn too quickly
+ * Support `RUN_AT_EXIT_HOOKS`.
+ * And [more](https://github.com/nevans/resque-pool/compare/v0.4.0...v0.5.0.rc1).
+
+Many thanks to the contributors! [JohnBat26](https://github.com/JohnBat26), Eric
+Chapweske, [werkshy](https://github.com/werkshy),
+[spajus](https://github.com/spajus), [greysteil](https://github.com/greysteil),
+[tjsousa](https://github.com/tjsousa), [jkrall](https://github.com/jkrall),
+[zmillman](https://github.com/zmillman), [nevans](http://github.com/nevans).
+
+## 0.4.0 (2015-01-28)
+
+Another _long_ overdue maintenance release.  Many users had been running the
+various release candidates in production for over 16 months.  Better
+Heroku/`TERM_CHILD` support, better `upstart` process group control, ERB in the
+config file, not-insane package size, and more.
+
+Many thanks to the contributors!
+
+ * Better `TERM_CHILD` support (useful for Heroku or anywhere else that only
+   sends `TERM` to quit) [@rayh](https://github.com/rayh) and
+   [@jjulian](https://github.com/jjulian)
+ * [@jjulian](https://github.com/jjulian):
+   * 0.3.0 accidentally packaged up 13MB of extra files!  OOOPS... SORRY!
+   * better MacOS X compatibility
+   * missing LICENCE in gemspec
+ * [@jasonrclark](https://github.com/jasonrclark): `after_prefork` hook manages
+   an array of hooks, rather than one single hook
+ * [@mlanett](https://github.com/mlanett): Parse ERB in the config file (_very_
+   useful for hostname/environment switched configuration)
+ * [@xjlu](https://github.com/xjlu): Match the task deps in resque:work
+ * [@darbyfrey](https://github.com/darbyfrey): Fixing deprecation warnings in
+   newer versions of resque
+ * [@ewoodh20](https://github.com/ewoodh20): Use `Rails.env` if available
+   (`RAILS_ENV` is deprecated)
+ * [@dlackty](https://github.com/dlackty): example `god` config file
+ * [@mattdbridges](https://github.com/mattdbridges): fix order dependent specs
+ * [@nevans](https://github.com/nevans):
+   * Ignore `WINCH` signal when running non-daemonized (often in the terminal)
+   * Do not run children in the same process group (solves problems with `upstart`
+     sending `TERM` to all processes at once)
 
 ## 0.3.0 (2012-05-22)
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,17 @@ the following into `lib/tasks/resque.rake`:
       end
     end
 
+
+For normal work with fresh resque and resque-scheduler gems add next lines in lib/rake/resque.rake
+
+```ruby
+task 'resque:pool:setup' do
+  Resque::Pool.after_prefork do |job|
+    Resque.redis.client.reconnect
+  end
+end
+```
+
 ### Start the pool manager
 
 Then you can start the queues via:

--- a/lib/resque/pool.rb
+++ b/lib/resque/pool.rb
@@ -395,6 +395,7 @@ module Resque
       worker = create_worker(queues)
       pid = fork do
         Process.setpgrp unless Resque::Pool.single_process_group
+        worker.worker_parent_pid = Process.pid
         log_worker "Starting worker #{worker}"
         call_after_prefork!
         reset_sig_handlers!
@@ -407,6 +408,7 @@ module Resque
     def create_worker(queues)
       queues = queues.to_s.split(',')
       worker = ::Resque::Worker.new(*queues)
+      worker.pool_master_pid = Process.pid
       worker.term_timeout = ENV['RESQUE_TERM_TIMEOUT'] || 4.0
       worker.term_child = ENV['TERM_CHILD']
       if worker.respond_to?(:run_at_exit_hooks=)

--- a/lib/resque/pool.rb
+++ b/lib/resque/pool.rb
@@ -411,6 +411,7 @@ module Resque
       worker = ::Resque::Worker.new(*queues)
       worker.term_timeout = ENV['RESQUE_TERM_TIMEOUT'] || 4.0
       worker.term_child = ENV['TERM_CHILD']
+      worker.run_at_exit_hooks = ENV['RUN_AT_EXIT_HOOKS'] || false
       if ENV['LOGGING'] || ENV['VERBOSE']
         worker.verbose = ENV['LOGGING'] || ENV['VERBOSE']
       end

--- a/lib/resque/pool.rb
+++ b/lib/resque/pool.rb
@@ -59,7 +59,7 @@ module Resque
     # Config: class methods to start up the pool using the default config {{{
 
     @config_files = ["resque-pool.yml", "config/resque-pool.yml"]
-    class << self; attr_accessor :config_files, :app_name; end
+    class << self; attr_accessor :config_files, :app_name, :spawn_delay; end
 
     def self.app_name
       @app_name ||= File.basename(Dir.pwd)
@@ -375,6 +375,7 @@ module Resque
     def spawn_missing_workers_for(queues)
       worker_delta_for(queues).times do |nr|
         spawn_worker!(queues)
+        sleep Resque::Pool.spawn_delay if Resque::Pool.spawn_delay
       end
     end
 

--- a/lib/resque/pool.rb
+++ b/lib/resque/pool.rb
@@ -31,7 +31,7 @@ module Resque
     # The `after_prefork` hooks will be run in workers if you are using the
     # preforking master worker to save memory. Use these hooks to reload
     # database connections and so forth to ensure that they're not shared
-    # among workers.
+    # among workers. The worker instance is passed as an argument to the block.
     #
     # Call with a block to set a hook.
     # Call with no arguments to return all registered hooks.
@@ -49,9 +49,9 @@ module Resque
       @after_prefork = [after_prefork]
     end
 
-    def call_after_prefork!
+    def call_after_prefork!(worker)
       self.class.after_prefork.each do |hook|
-        hook.call
+        hook.call(worker)
       end
     end
 
@@ -398,7 +398,7 @@ module Resque
       pid = fork do
         Process.setpgrp unless Resque::Pool.single_process_group
         log_worker "Starting worker #{worker}"
-        call_after_prefork!
+        call_after_prefork!(worker)
         reset_sig_handlers!
         #self_pipe.each {|io| io.close }
         worker.work(ENV['INTERVAL'] || DEFAULT_WORKER_INTERVAL) # interval, will block

--- a/lib/resque/pool.rb
+++ b/lib/resque/pool.rb
@@ -411,7 +411,10 @@ module Resque
       worker = ::Resque::Worker.new(*queues)
       worker.term_timeout = ENV['RESQUE_TERM_TIMEOUT'] || 4.0
       worker.term_child = ENV['TERM_CHILD']
-      worker.run_at_exit_hooks = ENV['RUN_AT_EXIT_HOOKS'] || false
+      if worker.respond_to?(:run_at_exit_hooks=)
+        # resque doesn't support this until 1.24, but we support 1.22
+        worker.run_at_exit_hooks = ENV['RUN_AT_EXIT_HOOKS'] || false
+      end
       if ENV['LOGGING'] || ENV['VERBOSE']
         worker.verbose = ENV['LOGGING'] || ENV['VERBOSE']
       end

--- a/lib/resque/pool/cli.rb
+++ b/lib/resque/pool/cli.rb
@@ -1,10 +1,13 @@
 require 'trollop'
 require 'resque/pool'
+require 'resque/pool/logging'
 require 'fileutils'
 
 module Resque
   class Pool
     module CLI
+      include Logging
+      extend  Logging
       extend self
 
       def run
@@ -113,6 +116,12 @@ where [options] are:
           Resque::Pool.term_behavior = "graceful_worker_shutdown_and_wait"
         elsif opts[:term_graceful]
           Resque::Pool.term_behavior = "graceful_worker_shutdown"
+        elsif ENV["TERM_CHILD"]
+          log "TERM_CHILD enabled, so will user 'term-graceful-and-wait' behaviour"
+          Resque::Pool.term_behavior = "graceful_worker_shutdown_and_wait"
+        end
+        if ENV.include?("DYNO") && !ENV["TERM_CHILD"]
+          log "WARNING: Are you running on Heroku? You should probably set TERM_CHILD=1"
         end
       end
 

--- a/lib/resque/pool/cli.rb
+++ b/lib/resque/pool/cli.rb
@@ -38,6 +38,7 @@ where [options] are:
           opt :nosync, "Don't sync logfiles on every write"
           opt :pidfile, "PID file location",         :type => String,    :short => "-p"
           opt :environment, "Set RAILS_ENV/RACK_ENV/RESQUE_ENV", :type => String, :short => "-E"
+          opt :spawn_delay, "Delay in milliseconds between spawning missing workers", :type => Integer, :short => "-s"
           opt :term_graceful_wait, "On TERM signal, wait for workers to shut down gracefully"
           opt :term_graceful,      "On TERM signal, shut down workers gracefully"
           opt :term_immediate,     "On TERM signal, shut down workers immediately (default)"
@@ -113,6 +114,9 @@ where [options] are:
           Resque::Pool.term_behavior = "graceful_worker_shutdown_and_wait"
         elsif opts[:term_graceful]
           Resque::Pool.term_behavior = "graceful_worker_shutdown"
+        end
+        if opts[:spawn_delay]
+          Resque::Pool.spawn_delay = opts[:spawn_delay] * 0.001
         end
       end
 

--- a/lib/resque/pool/logging.rb
+++ b/lib/resque/pool/logging.rb
@@ -3,35 +3,76 @@ module Resque
     module Logging
       extend self
 
-      # more than a little bit complicated...
-      # copied this from Unicorn.
+      # This reopens ALL logfiles in the process that have been rotated
+      # using logrotate(8) (without copytruncate) or similar tools.
+      # A +File+ object is considered for reopening if it is:
+      #   1) opened with the O_APPEND and O_WRONLY flags
+      #   2) the current open file handle does not match its original open path
+      #   3) unbuffered (as far as userspace buffering goes, not O_SYNC)
+      # Returns the number of files reopened
+      #
+      # This was mostly copied from Unicorn 4.8.2 to simplify reopening
+      # logs in the same way that Unicorn does.  Original comments and 
+      # explanations are left intact.
       def self.reopen_logs!
-        log "Flushing logs"
-        [$stdout, $stderr].each do |fd|
-          if fd.instance_of? File
-            # skip if the file is the exact same inode and device
-            orig_st = fd.stat
-            begin
-              cur_st = File.stat(fd.path)
-              next if orig_st.ino == cur_st.ino && orig_st.dev == cur_st.dev
-            rescue Errno::ENOENT
+        to_reopen      = [ ]
+        reopened_count = 0
+
+        ObjectSpace.each_object(File) { |fp| is_log?(fp) and to_reopen << fp }
+        log "Flushing #{to_reopen.length} logs"
+
+        to_reopen.each do |fp|
+          orig_st = begin
+            fp.stat
+          rescue IOError, Errno::EBADF # race
+            next
+          end
+
+          begin
+            b = File.stat(fp.path)
+            # Skip if reopening wouldn't do anything
+            next if orig_st.ino == b.ino && orig_st.dev == b.dev
+          rescue Errno::ENOENT
+          end
+
+          begin
+            # stdin, stdout, stderr are special.  The following dance should
+            # guarantee there is no window where `fp' is unwritable in MRI
+            # (or any correct Ruby implementation).
+            #
+            # Fwiw, GVL has zero bearing here.  This is tricky because of
+            # the unavoidable existence of stdio FILE * pointers for
+            # std{in,out,err} in all programs which may use the standard C library
+            if fp.fileno <= 2
+              # We do not want to hit fclose(3)->dup(2) window for std{in,out,err}
+              # MRI will use freopen(3) here internally on std{in,out,err}
+              fp.reopen(fp.path, "a")
+            else
+              # We should not need this workaround, Ruby can be fixed:
+              #    http://bugs.ruby-lang.org/issues/9036
+              # MRI will not call call fclose(3) or freopen(3) here
+              # since there's no associated std{in,out,err} FILE * pointer
+              # This should atomically use dup3(2) (or dup2(2)) syscall
+              File.open(fp.path, "a") { |tmpfp| fp.reopen(tmpfp) }
             end
-            # match up the encoding
-            open_arg = 'a'
-            if fd.respond_to?(:external_encoding) && enc = fd.external_encoding
-              open_arg << ":#{enc.to_s}"
-              enc = fd.internal_encoding and open_arg << ":#{enc.to_s}"
+
+            fp.sync = true
+            fp.flush # IO#sync=true may not implicitly flush
+            new_st = fp.stat
+
+            # this should only happen in the master:
+            if orig_st.uid != new_st.uid || orig_st.gid != new_st.gid
+              fp.chown(orig_st.uid, orig_st.gid)
             end
-            # match up buffering (does reopen reset this?)
-            sync = fd.sync
-            # sync to disk
-            fd.fsync
-            # reopen, and set ruby buffering appropriately
-            fd.reopen fd.path, open_arg
-            fd.sync = sync
-            log "Reopened logfile: #{fd.path}"
+
+            log "Reopened logfile: #{fp.path}"
+            reopened_count += 1
+          rescue IOError, Errno::EBADF
+            # not much we can do...
           end
         end
+
+        reopened_count
       end
 
       # Given a string, sets the procline ($0)
@@ -43,12 +84,14 @@ module Resque
 
       # TODO: make this use an actual logger
       def log(message)
+        return if $skip_logging
         puts "resque-pool-manager#{app}[#{Process.pid}]: #{message}"
         #$stdout.fsync
       end
 
       # TODO: make this use an actual logger
       def log_worker(message)
+        return if $skip_logging
         puts "resque-pool-worker#{app}[#{Process.pid}]: #{message}"
         #$stdout.fsync
       end
@@ -58,6 +101,20 @@ module Resque
         app_name   = self.respond_to?(:app_name)       && self.app_name
         app_name ||= self.class.respond_to?(:app_name) && self.class.app_name
         app_name ? "[#{app_name}]" : ""
+      end
+
+      private
+
+      # Used by reopen_logs, borrowed from Unicorn...
+      def self.is_log?(fp)
+        append_flags = File::WRONLY | File::APPEND
+
+        ! fp.closed? &&
+          fp.stat.file? &&
+          fp.sync &&
+          (fp.fcntl(Fcntl::F_GETFL) & append_flags) == append_flags
+        rescue IOError, Errno::EBADF
+          false
       end
 
     end

--- a/lib/resque/pool/pooled_worker.rb
+++ b/lib/resque/pool/pooled_worker.rb
@@ -2,14 +2,26 @@ require 'resque/worker'
 
 class Resque::Pool
   module PooledWorker
-    def shutdown_with_pool
-      shutdown_without_pool || Process.ppid == 1
+
+    def initialize_with_pool(*args)
+      @pool_master_pid = Process.pid
+      initialize_without_pool(*args)
+    end
+
+    def pool_master_has_gone_away?
+      @pool_master_pid && @pool_master_pid != Process.ppid
+    end
+
+    def shutdown_with_pool?
+      shutdown_without_pool? || pool_master_has_gone_away?
     end
 
     def self.included(base)
       base.instance_eval do
-        alias_method :shutdown_without_pool, :shutdown?
-        alias_method :shutdown?, :shutdown_with_pool
+        alias_method :initialize_without_pool, :initialize
+        alias_method :initialize, :initialize_with_pool
+        alias_method :shutdown_without_pool?, :shutdown?
+        alias_method :shutdown?, :shutdown_with_pool?
       end
     end
 

--- a/lib/resque/pool/pooled_worker.rb
+++ b/lib/resque/pool/pooled_worker.rb
@@ -5,13 +5,17 @@ class Resque::Pool
     attr_accessor :pool_master_pid
     attr_accessor :worker_parent_pid
 
+    # We will return false if there are no potential_parent_pids, because that
+    # means we aren't even running inside resque-pool.
+    #
     # We can't just check if we've been re-parented to PID 1 (init) because we
     # want to support docker (which will make the pool master PID 1).
     #
     # We also check the worker_parent_pid, because resque-multi-jobs-fork calls
     # Worker#shutdown? from inside the worker child process.
     def pool_master_has_gone_away?
-      not potential_parent_pids.include?(Process.ppid)
+      pids = potential_parent_pids
+      pids.any? && !pids.include?(Process.ppid)
     end
 
     def potential_parent_pids

--- a/lib/resque/pool/version.rb
+++ b/lib/resque/pool/version.rb
@@ -1,5 +1,5 @@
 module Resque
   class Pool
-    VERSION = "0.4.0.rc3"
+    VERSION = "0.5.0.rc1"
   end
 end

--- a/lib/resque/pool/version.rb
+++ b/lib/resque/pool/version.rb
@@ -1,5 +1,5 @@
 module Resque
   class Pool
-    VERSION = "0.4.0.rc1"
+    VERSION = "0.4.0.rc3"
   end
 end

--- a/resque-pool.gemspec
+++ b/resque-pool.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   EOF
 
   s.add_dependency "resque",  "~> 1.22"
-  s.add_dependency "trollop", "~> 1.16"
+  s.add_dependency "trollop", "~> 2.0"
   s.add_dependency "rake"
   s.add_development_dependency "rspec",    "~> 2.10"
   s.add_development_dependency "cucumber", "~> 1.2"

--- a/spec/logging_spec.rb
+++ b/spec/logging_spec.rb
@@ -1,0 +1,124 @@
+require 'spec_helper'
+require 'tempfile'
+
+describe Resque::Pool::Logging do
+
+  let(:expect_flags) { File::WRONLY | File::APPEND }
+  
+  # Don't pollute the log output
+  before(:all) { $skip_logging = true }
+  after(:all) { $skip_logging = false }
+
+  context "when reopening logs" do
+
+    before(:each) do
+      @tmp     = Tempfile.new('')
+      @fp      = File.open(@tmp.path, 'ab')
+      @fp.sync = true
+      @ext     = @fp.external_encoding rescue nil
+      @int     = @fp.internal_encoding rescue nil
+      @before  = @fp.stat.inspect
+    end
+
+    after(:each) do
+      @tmp.close!
+      @fp.close
+    end
+
+    it "reopens logs noop" do
+      Resque::Pool::Logging.reopen_logs!.should == 0
+
+      @before.should == File.stat(@fp.path).inspect
+      @ext.should == (@fp.external_encoding rescue nil)
+      @int.should == (@fp.internal_encoding rescue nil)
+      expect_flags.should == (expect_flags & @fp.fcntl(Fcntl::F_GETFL))
+    end
+
+    it "reopens renamed logs" do
+      tmp_path = @tmp.path.freeze
+      to = Tempfile.new('')
+      File.rename(tmp_path, to.path)
+      File.exist?(tmp_path).should be_falsey
+
+      Resque::Pool::Logging.reopen_logs!.should == 1
+
+      tmp_path.should == @tmp.path
+      File.exist?(tmp_path).should be_truthy
+      @before.should_not == File.stat(tmp_path).inspect
+      @fp.stat.inspect.should == File.stat(tmp_path).inspect
+      @ext.should == (@fp.external_encoding rescue nil)
+      @int.should == (@fp.internal_encoding rescue nil)
+      expect_flags.should == (expect_flags & @fp.fcntl(Fcntl::F_GETFL))
+      @fp.sync.should be_truthy
+
+      to.close!
+    end
+  end
+
+  context "when reopening logs with external encoding" do
+    before(:each) do
+      @tmp      = Tempfile.new('')
+      @tmp_path = @tmp.path.dup.freeze
+    end
+
+    after(:each) do
+      @tmp.close!
+    end
+
+    it "reopens logs renamed with encoding" do
+      Encoding.list.each do |encoding|
+        File.open(@tmp_path, "a:#{encoding.to_s}") do |fp|
+          fp.sync = true
+          encoding.should == fp.external_encoding
+          fp.internal_encoding.should be_nil
+          File.unlink(@tmp_path)
+          File.exist?(@tmp_path).should be_falsey
+          Resque::Pool::Logging.reopen_logs!
+          
+          @tmp_path.should == fp.path
+          File.exist?(@tmp_path).should be_truthy
+          fp.stat.inspect.should == File.stat(@tmp_path).inspect
+          encoding.should == fp.external_encoding
+          fp.internal_encoding.should be_nil
+          expect_flags.should == (expect_flags & fp.fcntl(Fcntl::F_GETFL))
+          fp.sync.should be_truthy
+        end
+      end
+    end if STDIN.respond_to?(:external_encoding)
+
+    # This spec can take a while to run through all of the encodings...
+    it "reopens logs renamed with internal encoding" do
+      Encoding.list.each do |ext|
+        Encoding.list.each do |int|
+          next if ext == int
+          File.open(@tmp_path, "a:#{ext.to_s}:#{int.to_s}") do |fp|
+            fp.sync = true
+            ext.should == fp.external_encoding
+
+            if ext != Encoding::BINARY
+              int.should == fp.internal_encoding
+            end
+
+            File.unlink(@tmp_path)
+            File.exist?(@tmp_path).should be_falsey
+            Resque::Pool::Logging.reopen_logs!
+
+            @tmp_path.should == fp.path
+            File.exist?(@tmp_path).should be_truthy
+            fp.stat.inspect.should == File.stat(@tmp_path).inspect
+            ext.should == fp.external_encoding
+
+            if ext != Encoding::BINARY
+              int.should == fp.internal_encoding
+            end
+
+            expect_flags.should == (expect_flags & fp.fcntl(Fcntl::F_GETFL))
+            fp.sync.should be_truthy
+          end
+        end
+      end
+    end if STDIN.respond_to?(:external_encoding)
+
+  end
+
+end

--- a/spec/resque_pool_spec.rb
+++ b/spec/resque_pool_spec.rb
@@ -169,11 +169,13 @@ end
 describe Resque::Pool, "given after_prefork hook" do
   subject { Resque::Pool.new(nil) }
 
+  let(:worker) { double }
+
   context "with a single hook" do
     before { Resque::Pool.after_prefork { @called = true } }
 
     it "should call prefork" do
-      subject.call_after_prefork!
+      subject.call_after_prefork!(worker)
       @called.should == true
     end
   end
@@ -182,7 +184,7 @@ describe Resque::Pool, "given after_prefork hook" do
     before { Resque::Pool.after_prefork = Proc.new { @called = true } }
 
     it "should call prefork" do
-      subject.call_after_prefork!
+      subject.call_after_prefork!(worker)
       @called.should == true
     end
   end
@@ -194,9 +196,16 @@ describe Resque::Pool, "given after_prefork hook" do
     }
 
     it "should call both" do
-      subject.call_after_prefork!
+      subject.call_after_prefork!(worker)
       @called_first.should == true
       @called_second.should == true
     end
+  end
+
+  it "passes the worker instance to the hook" do
+    val = nil
+    Resque::Pool.after_prefork { |w| val = w }
+    subject.call_after_prefork!(worker)
+    val.should == worker
   end
 end


### PR DESCRIPTION
### Intro
- We are currently dependent on our forked version of resque-pool, however we would still like to update it to the newest version of resque-pool. This updates our fork to the newest version of resque-pool and then adds our forked changes.
- [x]  Passes all specs in the gem spec directory
- [x] [Passes CI](http://pa-ci.peopleadmin.com/view/Ad-hoc%20jobs/job/Ad-hoc%20Master%20Job/696/)
